### PR TITLE
Update outdated instructions to edit Laravel Passport's route prefix

### DIFF
--- a/guides/laravel-passport.md
+++ b/guides/laravel-passport.md
@@ -14,7 +14,7 @@ This is because Socialstream registers routes using the `oauth/{provider}` struc
 
 Alternatively, if you wish to keep the prefix Socialstream uses, you may alter add prefix to Passport's routes by editing the Passport config file. If you haven't already, publish Passport's config file:
 
-```php
+```sh
 php artisan vendor:publish --tag=passport-config
 ```
 

--- a/guides/laravel-passport.md
+++ b/guides/laravel-passport.md
@@ -12,10 +12,23 @@ This is because Socialstream registers routes using the `oauth/{provider}` struc
 'prefix' => 'auth',
 ```
 
-Alternatively, if you wish to keep the prefix Socialstream uses, you may alter add prefix to Passport's routes by adding the following to the `boot` method of your applications `AuthServiceProvider.php` file:
+Alternatively, if you wish to keep the prefix Socialstream uses, you may alter add prefix to Passport's routes by editing the Passport config file. If you haven't already, publish Passport's config file:
 
 ```php
-Passport::routes([
-    'prefix' => 'passport-oauth',
-]);
+php artisan vendor:publish --tag=passport-config
+```
+
+ Add the following to `config/passport.php`:
+
+```php
+    /*
+    |--------------------------------------------------------------------------
+    | Path prefix
+    |--------------------------------------------------------------------------
+    |
+    | Default is 'oauth'.
+    |
+    */
+
+    'path' => 'passport-oauth',
 ```


### PR DESCRIPTION
The SocialStream doc page on [Laravel Passport](https://docs.socialstream.dev/guides/laravel-passport) has directions on how to alter Passport's routes, but those directions are out of date and no longer work &mdash; the static function `routes()` no longer exists in the `Passport` class.

The easiest way to update the path prefix is to edit the config file, but this is unfortunately not covered in the official [Passport documentation](https://laravel.com/docs/10.x/passport).