### PR TITLE
Improve Passport route clarity and grammar

### DIFF
--- a/guides/laravel-passport.md
+++ b/guides/laravel-passport.md
@@ -12,13 +12,13 @@ This is because Socialstream registers routes using the `oauth/{provider}` struc
 'prefix' => 'auth',
 ```
 
-Alternatively, if you wish to keep the prefix Socialstream uses, you may alter add prefix to Passport's routes by editing the Passport config file. If you haven't already, publish Passport's config file:
+Alternatively, if you wish to keep the prefix Socialstream uses, you may edit Passport's route prefix in its config file. If you haven't already, publish Passport's config file:
 
 ```sh
 php artisan vendor:publish --tag=passport-config
 ```
 
- Add the following to `config/passport.php`:
+Add the following to `config/passport.php`:
 
 ```php
     /*


### PR DESCRIPTION
Thanks for the quick approval yesterday. Apparently we both missed a grammar error "you may alter add prefix". This is a fix for that, and what I hope is a clearer and more concise sentence overall.